### PR TITLE
Error text change for "send_invalid_address" & translation changes

### DIFF
--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -116,7 +116,7 @@
     <string name="send_close">Kapat</string>
     <string name="send_alert_dialog_ok">Tamam</string>
     <string name="send_alert_dialog_title">Geçersiz Girdi</string>
-    <string name="send_invalid_address">Geçersiz Varış Adresi</string>
+    <string name="send_invalid_address">Geçersiz bir adres girdiniz</string>
     <string name="send_insufficient_balance">Yetersiz Bakiye</string>
     <string name="send_enter_address">Lütfen bir adres girin</string>
     <string name="send_enter_amount">Lütfen bir miktar girin</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -115,7 +115,7 @@
     <string name="send_close">Close</string>
     <string name="send_alert_dialog_ok">OK</string>
     <string name="send_alert_dialog_title">Invalid Input</string>
-    <string name="send_invalid_address">Invalid Destination Address</string>
+    <string name="send_invalid_address">Address entered was invalid</string>
     <string name="send_insufficient_balance">Insufficient Balance</string>
     <string name="send_enter_address">Please enter an address</string>
     <string name="send_enter_amount">Please enter an amount</string>


### PR DESCRIPTION
Error text for "send_invalid_address" was changed to make it similar in style to the other error messages. And Turkish translation for that error is changed too.