### PR TITLE
Fixed a small question mark error in the translation

### DIFF
--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -142,7 +142,7 @@
     <string name="contact_view_header">Kişi:</string>
     <string name="contact_remove_header">Sil:</string>
     <string name="contact_remove_btn">Kişiyi Sil</string>
-    <string name="contact_remove_sure">%s? kişisini silmek istediğine emin misin?</string>
+    <string name="contact_remove_sure">%s kişisini silmek istediğine emin misin?</string>
     <!-- Export/Import -->
     <string name="contact_removed">%s rehberden silindi!</string>
     <string name="contact_export_none">Dışa aktarılabilecek bir kişi bulunamadı</string>


### PR DESCRIPTION
There was an excessive question mark in the delete contact pop up. I thought it was a part of the code itself. Removed it now.